### PR TITLE
(ci) Remove msvc-dev-cmd action

### DIFF
--- a/.github/workflows/push_build.yml
+++ b/.github/workflows/push_build.yml
@@ -135,8 +135,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
-    - name: Enable Developer Command Prompt
-      uses: ilammy/msvc-dev-cmd@v1.13.0
     - name: Set up Python 3.13
       uses: actions/setup-python@v6
       with:
@@ -159,8 +157,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
-    - name: Enable Developer Command Prompt
-      uses: ilammy/msvc-dev-cmd@v1.13.0
     - name: Set up Python 3.13
       uses: actions/setup-python@v6
       with:

--- a/.github/workflows/tag_build.yml
+++ b/.github/workflows/tag_build.yml
@@ -134,8 +134,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
-    - name: Enable Developer Command Prompt
-      uses: ilammy/msvc-dev-cmd@v1.13.0
     - name: Set up Python 3.13
       uses: actions/setup-python@v6
       with:
@@ -174,8 +172,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
-    - name: Enable Developer Command Prompt
-      uses: ilammy/msvc-dev-cmd@v1.13.0
     - name: Set up Python 3.13
       uses: actions/setup-python@v6
       with:


### PR DESCRIPTION
This action is running on Node 20 and is unmaintained, there's no clear replacement fork of it, and also it's not even necessary here apparently! Removes the last actions deprecation warning from builds.